### PR TITLE
Add temperature read feature from Honeywell

### DIFF
--- a/example/example.ino
+++ b/example/example.ino
@@ -3,10 +3,10 @@
 // create Honeywell_ABP instance
 // refer to datasheet for parameters
 Honeywell_ABP abp(
-  0x28,   // I2C address
-  0,      // minimum pressure
-  1,      // maximum pressure
-  "psi"   // pressure unit
+    0x28,   // I2C address
+    0,      // minimum pressure
+    1,      // maximum pressure
+    "psi"   // pressure unit
 );
 
 void setup() {
@@ -26,6 +26,9 @@ void loop() {
   Serial.print(abp.pressure());
   Serial.print(" ");
   Serial.println(abp.unit());
-
+  Serial.print(" ");
+  Serial.print("Temperature: ");
+  Serial.print(abp.temperature());
+  Serial.println(" ºC ");
   delay(500);
 }

--- a/src/Honeywell_ABP.cpp
+++ b/src/Honeywell_ABP.cpp
@@ -25,53 +25,65 @@ void Honeywell_ABP::set_unit(String unit_string) {
 }
 
 void Honeywell_ABP::update() {
-  Wire.requestFrom(_address, (uint8_t)2);
-  while(Wire.available()) {
+  Wire.requestFrom(_address, (uint8_t)4);
+  while (Wire.available())
+  {
     uint8_t data_byte_1 = Wire.read();
     uint8_t data_byte_2 = Wire.read();
+    uint8_t data_byte_3 = Wire.read();
+    uint8_t data_byte_4 = Wire.read();
     _status = Honeywell_ABP::Status(data_byte_1 >> 6);
     _bridge_data = (data_byte_1 << 8 | data_byte_2) & 0x3FFF;
+    _temperature_data = ((data_byte_3 << 8) | (data_byte_4)) >> 5;
   }
   _pressure = raw_to_pressure(_bridge_data);
+  _temperature = raw_to_temperature(_temperature_data);
 }
 
 float Honeywell_ABP::raw_to_pressure(uint16_t output) {
-  return float(constrain(output, _output_min, _output_max) - _output_min)
-    * (_p_max - _p_min) / (_output_max - _output_min) + _p_min;
+  return float(constrain(output, _output_min, _output_max) - _output_min) * (_p_max - _p_min) / (_output_max - _output_min) + _p_min;
 }
 
-const char* Honeywell_ABP::unit() const {
-  switch(_unit) {
-    case UNIT_PSI:
-      return "psi";
-    case UNIT_PA:
-      return "Pa";
-    case UNIT_KPA:
-      return "kPa";
-    case UNIT_MPA:
-      return "MPa";
-    case UNIT_MBAR:
-      return "mbar";
-    case UNIT_BAR:
-      return "bar";
-    case UNIT_UNKNOWN:
-      return "(unknown unit)";
-    default:
-      return "(unknown unit)";
+const char *Honeywell_ABP::unit() const
+{
+  switch (_unit)
+  {
+  case UNIT_PSI:
+    return "psi";
+  case UNIT_PA:
+    return "Pa";
+  case UNIT_KPA:
+    return "kPa";
+  case UNIT_MPA:
+    return "MPa";
+  case UNIT_MBAR:
+    return "mbar";
+  case UNIT_BAR:
+    return "bar";
+  case UNIT_UNKNOWN:
+    return "(unknown unit)";
+  default:
+    return "(unknown unit)";
   }
 }
 
-const char* Honeywell_ABP::error_msg() const {
-  switch(_status) {
-    case STATUS_NOERROR:
-      return "No error";
-    case STATUS_COMMANDMODE:
-      return "Device in command mode (this mode should not be seen during normal operation)";
-    case STATUS_STALEDATA:
-      return "Stale data";
-    case STATUS_DIAGNOTIC:
-      return "Diagnostic condition";
-    default:
-      return "Unknown error";
+const char *Honeywell_ABP::error_msg() const
+{
+  switch (_status)
+  {
+  case STATUS_NOERROR:
+    return "No error";
+  case STATUS_COMMANDMODE:
+    return "Device in command mode (this mode should not be seen during normal operation)";
+  case STATUS_STALEDATA:
+    return "Stale data";
+  case STATUS_DIAGNOTIC:
+    return "Diagnostic condition";
+  default:
+    return "Unknown error";
   }
+}
+
+float Honeywell_ABP::raw_to_temperature(uint16_t output) {
+  return (output * 0.0977) - 50;
 }

--- a/src/Honeywell_ABP.h
+++ b/src/Honeywell_ABP.h
@@ -41,6 +41,7 @@ public:
   void set_unit(String unit_string);
 
   float raw_to_pressure(uint16_t output);
+  float raw_to_temperature(uint16_t output);
   void update();
 
   // getter functions
@@ -48,6 +49,7 @@ public:
   uint8_t status() const {return _status;}
   uint16_t bridge_data() const {return _bridge_data;}
   float pressure() const {return _pressure;}
+  float temperature() const {return _temperature;}
   const char* unit() const;
   const char* error_msg() const;
 
@@ -67,9 +69,11 @@ private:
   uint16_t _output_max = 0x399A; // 90% of 2^14
 
   // sensor reading
-  Status _status;         // sensor status
-  uint16_t _bridge_data;  // raw bridge data (14-bit)
-  float _pressure;        // pressure converted from raw data
+  Status _status;             // sensor status
+  uint16_t _bridge_data;      // raw bridge data (14-bit)
+  uint16_t _temperature_data; // raw temperature data (14-bit)
+  float _pressure;            // pressure converted from raw data
+  float _temperature;         // temperature converted from raw data
 };
 
 #endif //HONEYWELL_ABP_H


### PR DESCRIPTION
Some sensors have the temperature outputs available to software read from i2c bus; See the [datasheet ](https://sensing.honeywell.com/honeywell-sensing-basic-board-mount-pressure-abp-series-datasheet-32305128-en.pdf) page 5 for more details.

So, with this pr, your library can read the pressure and temperature from honeywell sensors.

Main changes

example/example.ino:12

```C
void setup() {
  ...
  Serial.print(" ");
  Serial.print("Temperature: ");
  Serial.print(abp.temperature());
  Serial.println(" ºC ");
}
```

src/Honeywell_ABP.cpp:27

```C
void Honeywell_ABP::update() {
 + Wire.requestFrom(_address, (uint8_t)4);
  while (Wire.available())
  {
    uint8_t data_byte_1 = Wire.read();
    uint8_t data_byte_2 = Wire.read();
   + uint8_t data_byte_3 = Wire.read();
   + uint8_t data_byte_4 = Wire.read();
    _status = Honeywell_ABP::Status(data_byte_1 >> 6);
    _bridge_data = (data_byte_1 << 8 | data_byte_2) & 0x3FFF;
   + _temperature_data = ((data_byte_3 << 8) | (data_byte_4)) >> 5;
  }
  _pressure = raw_to_pressure(_bridge_data);
  + _temperature = raw_to_temperature(_temperature_data);
}
```

src/Honeywell_ABP.cpp:87
```C
float Honeywell_ABP::raw_to_temperature(uint16_t output) {
  return (output * 0.0977) - 50;
}
```